### PR TITLE
Add note about usage with Spring

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ expect { EventsNotifier.with(profile: profile).canceled(event).notify_now }.
 expect { EventsNotifier.with(profile: profile).canceled(event).notify_later}.
   to have_enqueued_notification(identify: '123', body: 'Alarma!')
 ```
+ 
+**NOTE:** test mode activated automatically if `RAILS_ENV` or `RACK_ENV` env variable is equal to "test". Otherwise add `require "abstract_notifier/testing/rspec"` to your `spec_helper.rb` / `rails_helper.rb` manually. This is also required if you're using Spring in test environment (e.g. with help of [spring-commands-rspec](https://github.com/jonleighton/spring-commands-rspec)).
 
 ## Related projects
 

--- a/lib/abstract_notifier/testing.rb
+++ b/lib/abstract_notifier/testing.rb
@@ -45,4 +45,4 @@ end
 
 AbstractNotifier::Notification.prepend AbstractNotifier::Testing::Notification
 
-require "abstract_notifier/testing/rspec" if defined?(RSpec)
+require "abstract_notifier/testing/rspec" if defined?(RSpec::Core)


### PR DESCRIPTION
- Add note about usage with Spring to readme
- Change the RSpec check to `defined?(RSpec::Core)`