### PR TITLE
Add 2 assertions for minitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,20 @@ expect { EventsNotifier.with(profile: profile).canceled(event).notify_later }
   .to have_enqueued_notification(identify: "123", body: "Alarma!")
 ```
 
+Abstract Notifier provides two convinient minitest assertions:
+
+```ruby
+require 'abstract_notifier/testing/minitest'
+
+assert_delivery identify: "123", body: "Alarma!" do
+  EventsNotifier.with(profile: profile).canceled(event).notify_now
+end
+
+assert_async_delivery identify: "123", body: "Alarma!" do
+  EventsNotifier.with(profile: profile).canceled(event).notify_later
+end
+```
+
 **NOTE:** test mode activated automatically if `RAILS_ENV` or `RACK_ENV` env variable is equal to "test". Otherwise add `require "abstract_notifier/testing/rspec"` to your `spec_helper.rb` / `rails_helper.rb` manually. This is also required if you're using Spring in test environment (e.g. with help of [spring-commands-rspec](https://github.com/jonleighton/spring-commands-rspec)).
 
 ## Related projects

--- a/README.md
+++ b/README.md
@@ -194,12 +194,18 @@ Abstract Notifier provides two convinient minitest assertions:
 ```ruby
 require 'abstract_notifier/testing/minitest'
 
-assert_delivery identify: "123", body: "Alarma!" do
-  EventsNotifier.with(profile: profile).canceled(event).notify_now
-end
+class EventsNotifierTestCase < Minitest::Test
+  include AbstractNotifier::TestHelper
 
-assert_async_delivery identify: "123", body: "Alarma!" do
-  EventsNotifier.with(profile: profile).canceled(event).notify_later
+  test 'canceled' do
+    assert_notifications_sent 1, identify: "123", body: "Alarma!" do
+      EventsNotifier.with(profile: profile).canceled(event).notify_now
+    end
+
+    assert_notifications_enqueued 1, identify: "123", body: "Alarma!" do
+      EventsNotifier.with(profile: profile).canceled(event).notify_later
+    end
+  end
 end
 ```
 

--- a/lib/abstract_notifier/testing.rb
+++ b/lib/abstract_notifier/testing.rb
@@ -46,3 +46,4 @@ end
 AbstractNotifier::Notification.prepend AbstractNotifier::Testing::Notification
 
 require "abstract_notifier/testing/rspec" if defined?(RSpec::Core)
+require "abstract_notifier/testing/minitest" if defined?(Minitest::Assertions)

--- a/lib/abstract_notifier/testing/minitest.rb
+++ b/lib/abstract_notifier/testing/minitest.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Minitest
+  module Assertions
+    def assert_delivery(args)
+      yield
+      assert_equal args, AbstractNotifier::Testing::Driver.deliveries.last
+    end
+
+    def assert_async_delivery(args)
+      yield
+      assert_equal args, AbstractNotifier::Testing::Driver.enqueued_deliveries.last
+    end
+  end
+end

--- a/lib/abstract_notifier/testing/minitest.rb
+++ b/lib/abstract_notifier/testing/minitest.rb
@@ -1,15 +1,41 @@
 # frozen_string_literal: true
 
-module Minitest
-  module Assertions
-    def assert_delivery(args)
+module AbstractNotifier
+  module TestHelper
+    def assert_notifications_sent(count, params)
       yield
-      assert_equal args, AbstractNotifier::Testing::Driver.deliveries.last
+      assert_equal deliveries.count, count
+      count.times do |i|
+        delivery = deliveries[0 - i]
+        msg = message(msg) { "Expected #{mu_pp(delivery)} to include #{mu_pp(params)}" }
+        assert hash_include?(delivery, params), msg
+      end
     end
 
-    def assert_async_delivery(args)
+    def assert_notifications_enqueued(count, params)
       yield
-      assert_equal args, AbstractNotifier::Testing::Driver.enqueued_deliveries.last
+      assert_equal enqueued_deliveries.count, count
+      count.times do |i|
+        delivery = enqueued_deliveries[0 - i]
+        msg = message(msg) { "Expected #{mu_pp(delivery)} to include #{mu_pp(params)}" }
+        assert hash_include?(delivery, params), msg
+      end
+    end
+
+    private
+
+    def deliveries
+      AbstractNotifier::Testing::Driver.deliveries
+    end
+
+    def enqueued_deliveries
+      AbstractNotifier::Testing::Driver.enqueued_deliveries
+    end
+
+    def hash_include?(haystack, needle)
+      needle.all? do |k, v|
+        haystack.key?(k) && haystack[k] == v
+      end
     end
   end
 end


### PR DESCRIPTION
## What is the purpose of this pull request?

The purpose of this PR is to add two assertions for the rails default minitest.

## What changes did you make? (overview)

Two assertions have been added that are useful for minitest users: assert_delivery and assert_async_delivery.

## Is there anything you'd like reviewers to focus on?

Are these things necessary for this gem or not?